### PR TITLE
Translate 'Beneficial Ownership Data Standard' in nav bar

### DIFF
--- a/oods/locale/es/LC_MESSAGES/sphinx.po
+++ b/oods/locale/es/LC_MESSAGES/sphinx.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: standard_theme 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-02 16:51+0000\n"
+"POT-Creation-Date: 2019-07-18 15:56+0000\n"
 "PO-Revision-Date: 2019-02-02 16:10+0000\n"
 "Last-Translator: Amy Guy <amy.guy@opendataservices.coop>, 2019\n"
 "Language-Team: Spanish (https://www.transifex.com/OpenDataServices/teams/95583/es/)\n"
@@ -49,6 +49,10 @@ msgstr ""
 
 #: oods/sphinxtheme/globaltoc.html:12 oods/sphinxtheme/navbar.html:34
 msgid "About"
+msgstr ""
+
+#: oods/sphinxtheme/navbar.html:5
+msgid " Beneficial Ownership Data Standard "
 msgstr ""
 
 #: oods/sphinxtheme/prevnext.html:6

--- a/oods/locale/fr/LC_MESSAGES/sphinx.po
+++ b/oods/locale/fr/LC_MESSAGES/sphinx.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: standard_theme 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-02 16:51+0000\n"
+"POT-Creation-Date: 2019-07-18 15:56+0000\n"
 "PO-Revision-Date: 2019-02-02 16:10+0000\n"
 "Last-Translator: Amy Guy <amy.guy@opendataservices.coop>, 2019\n"
 "Language-Team: French (https://www.transifex.com/OpenDataServices/teams/95583/fr/)\n"
@@ -49,6 +49,10 @@ msgstr ""
 
 #: oods/sphinxtheme/globaltoc.html:12 oods/sphinxtheme/navbar.html:34
 msgid "About"
+msgstr ""
+
+#: oods/sphinxtheme/navbar.html:5
+msgid " Beneficial Ownership Data Standard "
 msgstr ""
 
 #: oods/sphinxtheme/prevnext.html:6

--- a/oods/locale/ru/LC_MESSAGES/sphinx.po
+++ b/oods/locale/ru/LC_MESSAGES/sphinx.po
@@ -6,15 +6,16 @@
 # 
 # Translators:
 # Valery Gusak <valery.gusak@gmail.com>, 2019
+# Amy Guy <amy.guy@opendataservices.coop>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: standard_theme 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-02 16:51+0000\n"
+"POT-Creation-Date: 2019-07-18 15:56+0000\n"
 "PO-Revision-Date: 2019-02-02 16:10+0000\n"
-"Last-Translator: Valery Gusak <valery.gusak@gmail.com>, 2019\n"
+"Last-Translator: Amy Guy <amy.guy@opendataservices.coop>, 2019\n"
 "Language-Team: Russian (https://www.transifex.com/OpenDataServices/teams/95583/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,6 +51,10 @@ msgstr "Панель инструментов"
 #: oods/sphinxtheme/globaltoc.html:12 oods/sphinxtheme/navbar.html:34
 msgid "About"
 msgstr "О Стандарте"
+
+#: oods/sphinxtheme/navbar.html:5
+msgid " Beneficial Ownership Data Standard "
+msgstr "Стандарт данных о бенефициарном владении"
 
 #: oods/sphinxtheme/prevnext.html:6
 msgid "Previous"

--- a/oods/locale/sphinx.pot
+++ b/oods/locale/sphinx.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: standard_theme 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-02 16:51+0000\n"
+"POT-Creation-Date: 2019-07-18 15:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr ""
 
 #: oods/sphinxtheme/globaltoc.html:12 oods/sphinxtheme/navbar.html:34
 msgid "About"
+msgstr ""
+
+#: oods/sphinxtheme/navbar.html:5
+msgid " Beneficial Ownership Data Standard "
 msgstr ""
 
 #: oods/sphinxtheme/prevnext.html:6

--- a/oods/sphinxtheme/navbar.html
+++ b/oods/sphinxtheme/navbar.html
@@ -2,7 +2,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-{{ theme_navbar_color_class }} bg-{{ theme_navbar_bg_class }} py-0 sticky-top">
     <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-        {{ project }}
+        {% trans %} Beneficial Ownership Data Standard {% endtrans %}
     </a>
 
     <button class="navbar-toggler mr-4" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
See #48 

I took the liberty of pulling down the Russian translation as well by copying it from elsewhere in transifex, mainly for testing purposes, but if I got it right then that's a bit less work for the translators. Needs a native speaker to review if this particular version of the translation makes sense as the page header. If it's not, correcting it in transifex and pulling down the translations again is all that will be needed.