### PR TITLE
Enable version warning

### DIFF
--- a/oods/sphinxtheme/layout.html
+++ b/oods/sphinxtheme/layout.html
@@ -100,7 +100,7 @@
             </div>
         </div>
         <div class="col-lg-9">
-            <div class="oods-main">
+            <div class="oods-main" role="main">
                 {% include "breadcrumbsedit.html" %}
 
                 <div class="oods-main-document">


### PR DESCRIPTION
Readthedocs [automatic 'not latest version' warning](https://docs.readthedocs.io/en/stable/versions.html#version-warning) is only injected in a `div` with `role="main"`.

This will fix #67. Note that the warning only shows up on branches which are named with semantic versioning (eg. `0.1.0`, not `dev-add-widget`) but I think that will be fine for the production docs as dev branches shouldn't show up in the flyout menu, and are likely to be ahead of latest rather than behind.

![Screenshot at 2022-01-06 13-16-28](https://user-images.githubusercontent.com/466229/148393661-d6d66a99-aa5d-4c28-b7cf-2f9e59df39b9.png)
