### PR TITLE
Edit to navbar item (schema -> standard)

### DIFF
--- a/oods/sphinxtheme/navbar.html
+++ b/oods/sphinxtheme/navbar.html
@@ -17,7 +17,7 @@
                 <a class="nav-link py-2" href="{{ pathto('primer/index') }}">{% trans %}Primer{% endtrans %}</a>
             </li>
             <li class="nav-item{% if currently_in == 'schema' %} active{% endif %} mx-xl-2">
-                <a class="nav-link py-2" href="{{ pathto('schema/index') }}">{% trans %}Data Schema{% endtrans %}</a>
+                <a class="nav-link py-2" href="{{ pathto('standard/index') }}">{% trans %}Data Standard{% endtrans %}</a>
             </li>
             {#
             <li class="nav-item{% if currently_in == 'userguides' %} active{% endif %} mx-xl-2">


### PR DESCRIPTION
We've renamed a section of the docs. (See [this PR in the data standard repo](https://github.com/openownership/data-standard/pull/661).) So we need to update this navbar item and link.